### PR TITLE
Claim to Group mapper: Rework to support patterns and formatting options

### DIFF
--- a/src/main/java/cloud/appuio/keycloak/extensions/mappers/ClaimToAttributeMapper.java
+++ b/src/main/java/cloud/appuio/keycloak/extensions/mappers/ClaimToAttributeMapper.java
@@ -160,11 +160,11 @@ public class ClaimToAttributeMapper extends AbstractClaimMapper {
         }
 
         boolean enabledTrimWhitespace() {
-            return Boolean.parseBoolean(map.getOrDefault(GroupNameFormatter.TRIM_WHITESPACE_PROPERTY, String.valueOf(true)));
+            return Boolean.parseBoolean(map.getOrDefault(GroupNameFormatter.TRIM_WHITESPACE_PROPERTY, String.valueOf(false)));
         }
 
         boolean enabledToLowerCase() {
-            return Boolean.parseBoolean(map.getOrDefault(GroupNameFormatter.TO_LOWERCASE_PROPERTY, String.valueOf(true)));
+            return Boolean.parseBoolean(map.getOrDefault(GroupNameFormatter.TO_LOWERCASE_PROPERTY, String.valueOf(false)));
         }
 
         String getClaimName() {

--- a/src/main/java/cloud/appuio/keycloak/extensions/mappers/ClaimToAttributeMapper.java
+++ b/src/main/java/cloud/appuio/keycloak/extensions/mappers/ClaimToAttributeMapper.java
@@ -28,7 +28,7 @@ public class ClaimToAttributeMapper extends AbstractClaimMapper {
     }
 
     void extractClaimToAttribute(RealmModel realm, IdentityProviderMapperModel mapperModel, UserModel user, MapperConfig config, BrokeredIdentityContext context) {
-        // check if mapper is configured correctly.
+        // abort if mapper is configured incorrectly.
         if (config.getClaimName().equals("")) return;
         if (config.getTargetAttributeKey().equals("")) return;
 

--- a/src/main/java/cloud/appuio/keycloak/extensions/mappers/ClaimToGroupMapper.java
+++ b/src/main/java/cloud/appuio/keycloak/extensions/mappers/ClaimToGroupMapper.java
@@ -124,11 +124,11 @@ public class ClaimToGroupMapper extends AbstractClaimMapper {
         }
 
         boolean enabledTrimWhitespace() {
-            return Boolean.parseBoolean(map.getOrDefault(GroupNameFormatter.TRIM_WHITESPACE_PROPERTY, String.valueOf(true)));
+            return Boolean.parseBoolean(map.getOrDefault(GroupNameFormatter.TRIM_WHITESPACE_PROPERTY, String.valueOf(false)));
         }
 
         boolean enabledToLowerCase() {
-            return Boolean.parseBoolean(map.getOrDefault(GroupNameFormatter.TO_LOWERCASE_PROPERTY, String.valueOf(true)));
+            return Boolean.parseBoolean(map.getOrDefault(GroupNameFormatter.TO_LOWERCASE_PROPERTY, String.valueOf(false)));
         }
 
         String getTrimPrefix() {

--- a/src/main/java/cloud/appuio/keycloak/extensions/mappers/ClaimToGroupMapper.java
+++ b/src/main/java/cloud/appuio/keycloak/extensions/mappers/ClaimToGroupMapper.java
@@ -17,9 +17,11 @@ import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.models.*;
 import org.keycloak.provider.ProviderConfigProperty;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Class with the implementation of the identity provider mapper that sync the user's groups
@@ -27,61 +29,135 @@ import java.util.stream.Stream;
  */
 public class ClaimToGroupMapper extends AbstractClaimMapper {
 
-    private static final Logger logger = Logger.getLogger(ClaimToGroupMapper.class);
-
-    // global properties -------------------------------------
-
-    private static final String PROVIDER_ID = "oidc-group-idp-mapper";
-
-    private static final String[] COMPATIBLE_PROVIDERS = {
-            KeycloakOIDCIdentityProviderFactory.PROVIDER_ID, OIDCIdentityProviderFactory.PROVIDER_ID
-    };
-
-    private static final List<ProviderConfigProperty> CONFIG_PROPERTIES = new ArrayList<>();
-
-    private static final String CONTAINS_TEXT = "contains_text";
-
-    private static final String CREATE_GROUPS = "create_groups";
-
-    static {
-        var claimProperty = new ProviderConfigProperty();
-        claimProperty.setName(CLAIM);
-        claimProperty.setLabel("Claim");
-        claimProperty.setHelpText(
-                "Name of claim to search for in token. This claim must be a string array with "
-                        + "the names of the groups which the user is member. You can reference nested claims using a "
-                        + "'.', i.e. 'address.locality'. To use dot (.) literally, escape it with backslash (\\.)");
-        claimProperty.setType(ProviderConfigProperty.STRING_TYPE);
-        CONFIG_PROPERTIES.add(claimProperty);
-
-        var containsTextProperty = new ProviderConfigProperty();
-        containsTextProperty.setName(CONTAINS_TEXT);
-        containsTextProperty.setLabel("Contains text");
-        containsTextProperty.setHelpText(
-                "Only sync groups that contains this text in its name. If empty, sync all groups.");
-        containsTextProperty.setType(ProviderConfigProperty.STRING_TYPE);
-        CONFIG_PROPERTIES.add(containsTextProperty);
-
-        var createGroupsProperty = new ProviderConfigProperty();
-        createGroupsProperty.setName(CREATE_GROUPS);
-        createGroupsProperty.setLabel("Create groups if not exists");
-        createGroupsProperty.setHelpText(
-                "Indicates if missing groups must be created in the realms. Otherwise, they will "
-                        + "be ignored.");
-        createGroupsProperty.setType(ProviderConfigProperty.BOOLEAN_TYPE);
-        CONFIG_PROPERTIES.add(createGroupsProperty);
+    @Override
+    public void importNewUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        this.syncGroups(realm, user, new MapperConfig(mapperModel.getConfig()), mapperModel, context);
     }
 
-    // properties --------------------------------------------
+    @Override
+    public void updateBrokeredUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        this.syncGroups(realm, user, new MapperConfig(mapperModel.getConfig()), mapperModel, context);
+    }
+
+    private void syncGroups(RealmModel realm, UserModel user, MapperConfig config, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        // abort if mapper is configured incorrectly.
+        if (config.getClaimName().equals("")) return;
+
+        var instrumentation = new Instrumentation(realm.getName(), mapperModel.getIdentityProviderAlias(), user.getUsername());
+
+        var claim = ClaimListExtractor.extractClaim(context, config.getClaimName());
+        if (claim.isEmpty()) {
+            instrumentation.noClaimForUser(config.getClaimName());
+            return;
+        }
+        doSyncGroups(realm, user, claim.get(), instrumentation, config);
+    }
+
+    void doSyncGroups(RealmModel realm, UserModel user, List<String> rawGroupNames, Instrumentation instrumentation, MapperConfig config) {
+        var formatter = new GroupNameFormatter()
+                .withTrimWhitespace(config.enabledTrimWhitespace())
+                .withToLowerCase(config.enabledToLowerCase());
+
+        var filteredGroupNames = rawGroupNames.stream()
+                .filter(rawName -> matchesPattern(config.getContainsText(), rawName))
+                .map(this::replaceInvalidCharacters)
+                .map(formatter::format)
+                .collect(Collectors.toSet());
+
+        if (config.enabledCreateGroups()) {
+            createMissingGroups(realm, filteredGroupNames, instrumentation);
+        }
+
+        leaveGroupsNotInClaim(user, filteredGroupNames, instrumentation);
+        joinGroupsInClaim(realm, user, filteredGroupNames, instrumentation);
+    }
+
+    private boolean matchesPattern(String pattern, String rawName) {
+        return isEmpty(pattern) || rawName.matches(pattern);
+    }
+
+    private void joinGroupsInClaim(RealmModel realm, UserModel user, Set<String> groupNames, Instrumentation instrumentation) {
+        var joinedGroupNames = realm.getGroupsStream()
+                .filter(group -> groupNames.contains(group.getName()))
+                .filter(group -> !user.isMemberOf(group))
+                .peek(user::joinGroup)
+                .map(GroupModel::getName)
+                .collect(Collectors.joining(", "));
+        instrumentation.joinedGroups(joinedGroupNames);
+    }
+
+    private void leaveGroupsNotInClaim(UserModel user, Set<String> groupNames, Instrumentation instrumentation) {
+        var leftGroupNames = user.getGroupsStream()
+                .filter(group -> !groupNames.contains(group.getName()))
+                .peek(user::leaveGroup)
+                .map(GroupModel::getName)
+                .collect(Collectors.joining(", "));
+        instrumentation.leftGroups(leftGroupNames);
+    }
+
+    private void createMissingGroups(RealmModel realm, Set<String> groupNames, Instrumentation instrumentation) {
+        var newGroupNames = groupNames.stream()
+                .filter(groupName -> realm.getGroupsStream()
+                        .map(GroupModel::getName)
+                        .noneMatch(existingGroup -> existingGroup.equals(groupName)))
+                .peek(realm::createGroup)
+                .collect(Collectors.joining(", "));
+        instrumentation.createdGroups(newGroupNames);
+    }
+
+    String replaceInvalidCharacters(String groupName) {
+        return groupName.replaceFirst("^/", "").replace("/", "-");
+    }
+
+    private boolean isEmpty(String str) {
+        return str == null || str.length() == 0;
+    }
+
+    public static final String CONTAINS_TEXT = "contains_text";
+    public static final String CREATE_GROUPS = "create_groups";
+
+    static class MapperConfig {
+        Map<String, String> map;
+
+        MapperConfig(Map<String, String> config) {
+            this.map = config;
+        }
+
+        String getClaimName() {
+            return map.getOrDefault(CLAIM, "");
+        }
+
+        boolean enabledTrimWhitespace() {
+            return Boolean.parseBoolean(map.getOrDefault(GroupNameFormatter.TRIM_WHITESPACE_PROPERTY, String.valueOf(true)));
+        }
+
+        boolean enabledToLowerCase() {
+            return Boolean.parseBoolean(map.getOrDefault(GroupNameFormatter.TO_LOWERCASE_PROPERTY, String.valueOf(true)));
+        }
+
+        String getTrimPrefix() {
+            return map.getOrDefault(GroupNameFormatter.TRIM_PREFIX_PROPERTY, "");
+        }
+
+        String getContainsText() {
+            return map.getOrDefault(CONTAINS_TEXT, "");
+        }
+
+        boolean enabledCreateGroups() {
+            return Boolean.parseBoolean(map.getOrDefault(CREATE_GROUPS, String.valueOf(false)));
+        }
+    }
 
     @Override
     public String getId() {
-        return PROVIDER_ID;
+        return "oidc-group-idp-mapper";
     }
 
     @Override
     public String[] getCompatibleProviders() {
-        return COMPATIBLE_PROVIDERS;
+        return new String[]{
+                KeycloakOIDCIdentityProviderFactory.PROVIDER_ID, OIDCIdentityProviderFactory.PROVIDER_ID
+        };
     }
 
     @Override
@@ -101,170 +177,68 @@ public class ClaimToGroupMapper extends AbstractClaimMapper {
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return CONFIG_PROPERTIES;
-    }
 
-    // actions -----------------------------------------------
+        var claimProperty = new ProviderConfigProperty(
+                CLAIM, "Claim name", null, ProviderConfigProperty.STRING_TYPE, ""
+        );
+        claimProperty.setHelpText("Name of claim to search for in token. " +
+                "This claim must be a string array with the names of the groups which the user is member. " +
+                "You can reference nested claims using a '.', i.e. 'address.locality'. " +
+                "To use dot (.) literally, escape it with backslash (\\.)");
 
-    @Override
-    public void importNewUser(
-            KeycloakSession session,
-            RealmModel realm,
-            UserModel user,
-            IdentityProviderMapperModel mapperModel,
-            BrokeredIdentityContext context) {
-        super.importNewUser(session, realm, user, mapperModel, context);
+        var containsTextProperty = new ProviderConfigProperty(
+                CONTAINS_TEXT, "Contains text", null, ProviderConfigProperty.STRING_TYPE, ""
+        );
+        containsTextProperty.setHelpText("Only sync groups that contains this text in its name. " +
+                "If empty, sync all groups.");
 
-        this.syncGroups(realm, user, mapperModel, context);
-    }
+        var createGroupsProperty = new ProviderConfigProperty(
+                CREATE_GROUPS, "Create groups if not exists", null, ProviderConfigProperty.BOOLEAN_TYPE, false
+        );
+        createGroupsProperty.setHelpText("Indicates if missing groups must be created in the realms. " +
+                "Otherwise, they will be ignored.");
 
-    @Override
-    public void updateBrokeredUser(
-            KeycloakSession session,
-            RealmModel realm,
-            UserModel user,
-            IdentityProviderMapperModel mapperModel,
-            BrokeredIdentityContext context) {
-
-        this.syncGroups(realm, user, mapperModel, context);
-    }
-
-    private void syncGroups(
-            RealmModel realm,
-            UserModel user,
-            IdentityProviderMapperModel mapperModel,
-            BrokeredIdentityContext context) {
-
-        // check configurations
-        var groupClaimName = mapperModel.getConfig().get(CLAIM);
-        var containsText = mapperModel.getConfig().get(CONTAINS_TEXT);
-        var createGroups = Boolean.valueOf(mapperModel.getConfig().get(CREATE_GROUPS));
-
-        if (isEmpty(groupClaimName)) return;
-
-        var claim = ClaimListExtractor.extractClaim(context, groupClaimName);
-        if (claim.isEmpty()) {
-            logger.debugf(
-                    "Realm [%s], IdP [%s]: no group claim (claim name: [%s]) for user [%s], ignoring...",
-                    realm.getName(),
-                    mapperModel.getIdentityProviderAlias(),
-                    groupClaimName,
-                    user.getUsername());
-            return;
-        }
-
-        logger.debugf(
-                "Realm [%s], IdP [%s]: starting mapping groups for user [%s]",
-                realm.getName(), mapperModel.getIdentityProviderAlias(), user.getUsername());
-
-        // get user current groups
-        var currentGroups = user.getGroupsStream()
-                .filter(g -> isEmpty(containsText) || g.getName().contains(containsText))
-                .collect(Collectors.toSet());
-
-        logger.debugf(
-                "Realm [%s], IdP [%s]: current groups for user [%s]: %s",
-                realm.getName(),
-                mapperModel.getIdentityProviderAlias(),
-                user.getUsername(),
-                currentGroups.stream().map(GroupModel::getName).collect(Collectors.joining(",")));
-
-        // map and filter the groups by name
-        var groupNamesFromClaim = claim.get().stream()
-                .filter(t -> isEmpty(containsText) || t.contains(containsText))
-                .map(this::replaceInvalidCharacters)
-                .collect(Collectors.toSet());
-
-        var newRealmGroups = filterNewRealmGroups(realm, groupNamesFromClaim, createGroups);
-
-        logger.debugf(
-                "Realm [%s], IdP [%s]: new groups for user [%s]: %s",
-                realm.getName(),
-                mapperModel.getIdentityProviderAlias(),
-                user.getUsername(),
-                newRealmGroups.stream().map(GroupModel::getName).collect(Collectors.joining(",")));
-
-        // Leave the groups where the user is not member of
-        findGroupsToBeRemoved(currentGroups, newRealmGroups).forEach(user::leaveGroup);
-
-        // Join the groups where the user is not yet member of
-        findGroupsToBeAdded(currentGroups, newRealmGroups).forEach(user::joinGroup);
-
-        logger.debugf(
-                "Realm [%s], IdP [%s]: finishing mapping groups for user [%s]",
-                realm.getName(), mapperModel.getIdentityProviderAlias(), user.getUsername());
-    }
-
-    String replaceInvalidCharacters(String groupName) {
-        return groupName.replaceFirst("^/", "").replace("/", "-");
-    }
-
-    /**
-     * Returns a stream that contains the groups that do not yet exist in the realm.
-     *
-     * @return new set that contains only the groups to create
-     */
-    private Set<GroupModel> filterNewRealmGroups(
-            RealmModel realm, Set<String> newGroupsNames, Boolean createGroups) {
-
-        Set<GroupModel> groups = new HashSet<>();
-
-        newGroupsNames.forEach(
-                groupName -> {
-                    Optional<GroupModel> group = findGroupByName(realm, groupName);
-
-                    // create group if not found
-                    group.ifPresentOrElse(
-                            groups::add,
-                            () -> {
-                                if (createGroups) {
-                                    createAndJoinGroup(realm, groups, groupName);
-                                }
-                            });
-                });
-
-        return groups;
-    }
-
-    private void createAndJoinGroup(RealmModel realm, Set<GroupModel> groups, String groupName) {
-        logger.debugf("Realm [%s]: creating group [%s]", realm.getName(), groupName);
-
-        var newGroup = realm.createGroup(groupName);
-        groups.add(newGroup);
-    }
-
-    private static Optional<GroupModel> findGroupByName(RealmModel realm, String name) {
-        return realm.getGroupsStream().filter(g -> g.getName().equals(name)).findFirst();
-    }
-
-    /**
-     * Subtracts newGroups from currentGroups.
-     */
-    static Stream<GroupModel> findGroupsToBeRemoved(
-            Set<GroupModel> currentGroups, Set<GroupModel> newGroups) {
-        var resultSet = new HashSet<>(currentGroups);
-        resultSet.removeAll(newGroups);
-        return resultSet.stream();
-    }
-
-    /**
-     * Subtracts current groups from newGroups.
-     */
-    static Stream<GroupModel> findGroupsToBeAdded(
-            Set<GroupModel> currentGroups, Set<GroupModel> newGroups) {
-        var resultSet = new HashSet<>(newGroups);
-
-        // (New - Current) will result in a set with the groups where the user will be added
-        resultSet.removeAll(currentGroups);
-        return resultSet.stream();
-    }
-
-    private static boolean isEmpty(String str) {
-        return str == null || str.length() == 0;
+        return List.of(claimProperty, containsTextProperty, createGroupsProperty);
     }
 
     @Override
     public boolean supportsSyncMode(IdentityProviderSyncMode syncMode) {
         return Arrays.asList(IdentityProviderSyncMode.IMPORT, IdentityProviderSyncMode.FORCE).contains(syncMode);
+    }
+
+    /**
+     * This class is meant to remove boilerplate from business logic by moving the logging statements but keep the meaning of it.
+     */
+    static class Instrumentation {
+        private static final Logger logger = Logger.getLogger(ClaimToGroupMapper.class);
+        private final String idpAlias;
+        private final String username;
+        private final String realmName;
+
+        Instrumentation(String realmName, String identityProviderAlias, String username) {
+            this.realmName = realmName;
+            this.idpAlias = identityProviderAlias;
+            this.username = username;
+        }
+
+        void noClaimForUser(String claimName) {
+            logger.debugf("Realm [%s], IdP [%s]: user [%s] has no claim: [%s], ignoring...",
+                    this.realmName, this.idpAlias, this.username, claimName);
+        }
+
+        void createdGroups(String newGroupNames) {
+            logger.debugf("Realm [%s], IdP [%s]: created new groups for user [%s]: [%s]",
+                    this.realmName, this.idpAlias, this.username, newGroupNames);
+        }
+
+        void joinedGroups(String joinedGroups) {
+            logger.debugf("Realm [%s], IdP [%s]: user [%s] joined groups: [%s]",
+                    this.realmName, this.idpAlias, this.username, joinedGroups);
+        }
+
+        void leftGroups(String leftGroupNames) {
+            logger.debugf("Realm [%s], IdP [%s]: user [%s] left groups: [%s]",
+                    this.realmName, this.idpAlias, this.username, leftGroupNames);
+        }
     }
 }

--- a/src/main/java/cloud/appuio/keycloak/extensions/mappers/ClaimToGroupMapper.java
+++ b/src/main/java/cloud/appuio/keycloak/extensions/mappers/ClaimToGroupMapper.java
@@ -76,9 +76,9 @@ public class ClaimToGroupMapper extends AbstractClaimMapper {
         return isEmpty(pattern) || rawName.matches(pattern);
     }
 
-    private void joinGroupsInClaim(RealmModel realm, UserModel user, Set<String> groupNames, Instrumentation instrumentation) {
+    private void joinGroupsInClaim(RealmModel realm, UserModel user, Set<String> groupNamesInClaim, Instrumentation instrumentation) {
         var joinedGroupNames = realm.getGroupsStream()
-                .filter(group -> groupNames.contains(group.getName()))
+                .filter(group -> groupNamesInClaim.contains(group.getName()))
                 .filter(group -> !user.isMemberOf(group))
                 .peek(user::joinGroup)
                 .map(GroupModel::getName)
@@ -86,9 +86,9 @@ public class ClaimToGroupMapper extends AbstractClaimMapper {
         instrumentation.joinedGroups(joinedGroupNames);
     }
 
-    private void leaveGroupsNotInClaim(UserModel user, Set<String> groupNames, Instrumentation instrumentation) {
+    private void leaveGroupsNotInClaim(UserModel user, Set<String> groupNamesInClaim, Instrumentation instrumentation) {
         var leftGroupNames = user.getGroupsStream()
-                .filter(group -> !groupNames.contains(group.getName()))
+                .filter(group -> !groupNamesInClaim.contains(group.getName()))
                 .peek(user::leaveGroup)
                 .map(GroupModel::getName)
                 .collect(Collectors.joining(", "));
@@ -133,10 +133,6 @@ public class ClaimToGroupMapper extends AbstractClaimMapper {
 
         boolean enabledToLowerCase() {
             return Boolean.parseBoolean(map.getOrDefault(GroupNameFormatter.TO_LOWERCASE_PROPERTY, String.valueOf(true)));
-        }
-
-        String getTrimPrefix() {
-            return map.getOrDefault(GroupNameFormatter.TRIM_PREFIX_PROPERTY, "");
         }
 
         String getContainsText() {
@@ -207,7 +203,7 @@ public class ClaimToGroupMapper extends AbstractClaimMapper {
     }
 
     /**
-     * This class is meant to remove boilerplate from business logic by moving the logging statements but keep the meaning of it.
+     * This class is meant to remove boilerplate from business logic by moving the logging calls but still provide meaning.
      */
     static class Instrumentation {
         private static final Logger logger = Logger.getLogger(ClaimToGroupMapper.class);

--- a/src/main/java/cloud/appuio/keycloak/extensions/mappers/GroupNameFormatter.java
+++ b/src/main/java/cloud/appuio/keycloak/extensions/mappers/GroupNameFormatter.java
@@ -54,12 +54,12 @@ public class GroupNameFormatter {
             TRIM_WHITESPACE_PROPERTY, "Trim whitespaces",
             "Removes leading and trailing whitespaces completely. " +
                     "Dashes and spaces between words are replaced with a single dash.",
-            ProviderConfigProperty.BOOLEAN_TYPE, true
+            ProviderConfigProperty.BOOLEAN_TYPE, false
     );
 
     public static final ProviderConfigProperty TO_LOWERCASE = new ProviderConfigProperty(
             TO_LOWERCASE_PROPERTY, "Lowercase names",
             "Transforms the strings to lower case. ",
-            ProviderConfigProperty.BOOLEAN_TYPE, true
+            ProviderConfigProperty.BOOLEAN_TYPE, false
     );
 }

--- a/src/test/java/cloud/appuio/keycloak/extensions/mappers/ClaimToGroupMapperTest.java
+++ b/src/test/java/cloud/appuio/keycloak/extensions/mappers/ClaimToGroupMapperTest.java
@@ -7,10 +7,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.mockito.Mockito;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,16 +28,78 @@ class ClaimToGroupMapperTest {
     void testSyncGroups_GivenListWithNewGroup_WhenCreateEnabled_ThenCreateAndJoinGroup() {
         var realm = Mockito.mock(RealmModel.class);
         var user = Mockito.mock(UserModel.class);
+        var createdGroup = Mockito.mock(GroupModel.class);
 
-        Mockito.when(realm.getGroupsStream()).thenReturn(Stream.empty(), Stream.empty());
+        //noinspection unchecked
+        Mockito.when(realm.getGroupsStream()).thenReturn(Stream.empty(), Stream.of(createdGroup));
+        Mockito.when(createdGroup.getName()).thenReturn("rose-canyon");
 
         var subject = new ClaimToGroupMapper();
         var config = newMapperConfig();
         setCreateGroupEnabled(config);
 
-        subject.doSyncGroups(realm, user, List.of("newGroup"), newInstrumentation(), config);
+        subject.doSyncGroups(realm, user, List.of("Rose Canyon"), newInstrumentation(), config);
 
-        Mockito.verify(realm).createGroup("newgroup");
+        Mockito.verify(realm).createGroup("rose-canyon");
+        Mockito.verify(user).joinGroup(createdGroup);
+        Mockito.verify(user, Mockito.never()).leaveGroup(Mockito.any());
+    }
+
+    @Test
+    void testSyncGroups_GivenListWithNewGroup_WhenCreateDisabled_ThenDoNothing() {
+        var realm = Mockito.mock(RealmModel.class);
+        var user = Mockito.mock(UserModel.class);
+
+        Mockito.when(realm.getGroupsStream()).thenReturn(Stream.empty());
+
+        var subject = new ClaimToGroupMapper();
+        var config = newMapperConfig();
+
+        subject.doSyncGroups(realm, user, List.of("Rose Canyon"), newInstrumentation(), config);
+
+        Mockito.verify(realm, Mockito.never()).createGroup(Mockito.anyString());
+        Mockito.verify(user, Mockito.never()).joinGroup(Mockito.any());
+        Mockito.verify(user, Mockito.never()).leaveGroup(Mockito.any());
+    }
+
+    @Test
+    void testSyncGroups_GivenListWithNewGroup_WhenGroupExists_ThenJoinGroup() {
+        var realm = Mockito.mock(RealmModel.class);
+        var user = Mockito.mock(UserModel.class);
+        var group = Mockito.mock(GroupModel.class);
+
+        Mockito.when(realm.getGroupsStream()).thenReturn(Stream.of(group));
+        Mockito.when(group.getName()).thenReturn("rose-canyon");
+
+        var subject = new ClaimToGroupMapper();
+        var config = newMapperConfig();
+
+        subject.doSyncGroups(realm, user, List.of("Rose Canyon"), newInstrumentation(), config);
+
+        Mockito.verify(realm, Mockito.never()).createGroup(Mockito.anyString());
+        Mockito.verify(user).joinGroup(group);
+        Mockito.verify(user, Mockito.never()).leaveGroup(Mockito.any());
+    }
+
+    @Test
+    void testSyncGroups_GivenListWithAbsentGroup_WhenUserInExistingGroup_ThenLeaveGroup() {
+        var realm = Mockito.mock(RealmModel.class);
+        var user = Mockito.mock(UserModel.class);
+        var groupToRemove = Mockito.mock(GroupModel.class);
+        var groupToKeep = Mockito.mock(GroupModel.class);
+
+        Mockito.when(user.getGroupsStream()).thenReturn(Stream.of(groupToRemove, groupToKeep));
+        Mockito.when(groupToKeep.getName()).thenReturn("keep-group");
+
+        var subject = new ClaimToGroupMapper();
+        var config = newMapperConfig();
+
+        subject.doSyncGroups(realm, user, List.of("keep group"), newInstrumentation(), config);
+
+        Mockito.verify(realm, Mockito.never()).createGroup(Mockito.anyString());
+        Mockito.verify(user, Mockito.never()).joinGroup(Mockito.any());
+        Mockito.verify(user).leaveGroup(groupToRemove);
+        Mockito.verify(user, Mockito.never()).leaveGroup(groupToKeep);
     }
 
     private ClaimToGroupMapper.Instrumentation newInstrumentation() {

--- a/src/test/java/cloud/appuio/keycloak/extensions/mappers/ClaimToGroupMapperTest.java
+++ b/src/test/java/cloud/appuio/keycloak/extensions/mappers/ClaimToGroupMapperTest.java
@@ -23,7 +23,7 @@ class ClaimToGroupMapperTest {
 
         //noinspection unchecked
         Mockito.when(realm.getGroupsStream()).thenReturn(Stream.empty(), Stream.of(createdGroup));
-        Mockito.when(createdGroup.getName()).thenReturn("rose-canyon");
+        Mockito.when(createdGroup.getName()).thenReturn("Rose Canyon");
 
         var subject = new ClaimToGroupMapper();
         var config = newMapperConfig();
@@ -31,7 +31,7 @@ class ClaimToGroupMapperTest {
 
         subject.doSyncGroups(realm, user, List.of("Rose Canyon"), newInstrumentation(), config);
 
-        Mockito.verify(realm).createGroup("rose-canyon");
+        Mockito.verify(realm).createGroup("Rose Canyon");
         Mockito.verify(user).joinGroup(createdGroup);
         Mockito.verify(user, Mockito.never()).leaveGroup(Mockito.any());
     }
@@ -60,7 +60,7 @@ class ClaimToGroupMapperTest {
         var group = Mockito.mock(GroupModel.class);
 
         Mockito.when(realm.getGroupsStream()).thenReturn(Stream.of(group));
-        Mockito.when(group.getName()).thenReturn("rose-canyon");
+        Mockito.when(group.getName()).thenReturn("Rose Canyon");
 
         var subject = new ClaimToGroupMapper();
         var config = newMapperConfig();
@@ -80,7 +80,7 @@ class ClaimToGroupMapperTest {
         var groupToKeep = Mockito.mock(GroupModel.class);
 
         Mockito.when(user.getGroupsStream()).thenReturn(Stream.of(groupToRemove, groupToKeep));
-        Mockito.when(groupToKeep.getName()).thenReturn("keep-group");
+        Mockito.when(groupToKeep.getName()).thenReturn("keep group");
 
         var subject = new ClaimToGroupMapper();
         var config = newMapperConfig();
@@ -94,13 +94,13 @@ class ClaimToGroupMapperTest {
     }
 
     @Test
-    void testFilterGroupNames_GivenEmptyListOfPattern_WhenDefaultConfig_ThenReturnFormatted() {
+    void testFilterGroupNames_GivenEmptyListOfPattern_WhenDefaultConfig_ThenReturnUnformatted() {
         var subject = new ClaimToGroupMapper();
         var config = newMapperConfig();
 
         var result = subject.filterGroupNames(List.of("Rose Canyon"), config);
 
-        assertThat(result).containsExactly("rose-canyon");
+        assertThat(result).containsExactly("Rose Canyon");
     }
 
     @Test
@@ -108,6 +108,8 @@ class ClaimToGroupMapperTest {
         var subject = new ClaimToGroupMapper();
         var config = newMapperConfig();
         setIncludePatterns(config, "^Rose.*");
+        setLowerCase(config);
+        setWhiteSpace(config);
 
         var result = subject.filterGroupNames(List.of("Rose Canyon", "Sapphire Stars"), config);
 
@@ -135,6 +137,14 @@ class ClaimToGroupMapperTest {
 
     private void setIncludePatterns(ClaimToGroupMapper.MapperConfig mapperConfig, String... patterns) {
         mapperConfig.map.put(ClaimToGroupMapper.INCLUDE_PATTERNS, String.join("##", patterns));
+    }
+
+    private void setLowerCase(ClaimToGroupMapper.MapperConfig mapperConfig) {
+        mapperConfig.map.put(GroupNameFormatter.TO_LOWERCASE_PROPERTY, Boolean.toString(true));
+    }
+
+    private void setWhiteSpace(ClaimToGroupMapper.MapperConfig mapperConfig) {
+        mapperConfig.map.put(GroupNameFormatter.TRIM_WHITESPACE_PROPERTY, Boolean.toString(true));
     }
 
     private ClaimToGroupMapper.MapperConfig newMapperConfig() {


### PR DESCRIPTION
## Summary

* Features a new and replaced property "Match patterns", which works similar like "Contains text", except multiple pattern can be provided. The group will be created and/or joined if any one of the pattern matches the group name.
* The group name supports the same Name formatter as `ClaimToAttribute` (Lowercasing, trimming whitespaces and prefix)

NOTE: Since the property got also its ID renamed, it may be necessary to recreate existing mappers.

Implementation notes:
* Split the main business part of `syncGroups` method to `doSyncGroups` that is easier to test.
* Similar to `ClaimToAttribute` mapper, there's now a dedicated `MapperConfig` class to ease property access and defaults.
* Created new dedicated `Instrumentation` class that is responsible for analytics (i.e. logging). This should keep the business functions free from boilerplate and improve readability.
* Added test cases
* Change default values of boolean properties to disabled/off since Keycloak admin console does not automatically set the toggles to "ON" when creating new mappers.

It's basically a rewrite and reordering things, the diff might be hard to decipher

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
